### PR TITLE
Intorduce pyright instead of mypy

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A [copier](https://github.com/copier-org/copier) template for generating Python 
 - [uv](https://docs.astral.sh/uv/)
 - [pytest](https://docs.pytest.org/)
 - [Ruff](https://docs.astral.sh/ruff/)
-- [mypy](https://www.mypy-lang.org/)
+- [pyright](https://github.com/microsoft/pyright)
 
 ## Prerequisites
 

--- a/copier.yml
+++ b/copier.yml
@@ -27,4 +27,4 @@ description:
 _subdirectory: template
 _tasks:
   - uv python pin {{ python_version }}
-  - uv add pytest ruff mypy --dev
+  - uv add pytest ruff pyright --dev

--- a/template/.gitignore
+++ b/template/.gitignore
@@ -25,10 +25,9 @@ ipython_config.py
 env/
 venv/
 
-# mypy
-.mypy_cache/
-.dmypy.json
-dmypy.json
+# pyright / pylance
+.pyright/
+pyrightconfig.json
 
 # Ruff
 .ruff_cache/

--- a/template/Makefile.jinja
+++ b/template/Makefile.jinja
@@ -14,8 +14,8 @@ test:
 lint:
 	echo "Running ruff..."
 	uv run ruff check
-	echo "Running mypy..."
-	uv run mypy .
+	echo "Running pyright..."
+	uv run pyright
 
 format:
 	uv run ruff format

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -38,3 +38,16 @@ select = [
     "N",    # naming
     "T100", # breakpoints (probably don't want these in prod!)
 ]
+
+[tool.pyright]
+include = ["src", "tests"]
+exclude = [
+    "**/__pycache__",
+    ".venv",
+    "build",
+    "dist",
+]
+pythonVersion = "{{ python_version }}"
+typeCheckingMode = "strict"
+reportMissingImports = true
+reportMissingTypeStubs = false


### PR DESCRIPTION
## Summary

Replace mypy with pyright as the type checker for generated Python projects.

## Changes

- Replace mypy with pyright in development dependencies
- Add pyright configuration in pyproject.toml with strict mode
- Update Makefile to use pyright command
- Update documentation and .gitignore